### PR TITLE
Implement an event information page

### DIFF
--- a/src/main/webapp/event-info-page/eventInfo.html
+++ b/src/main/webapp/event-info-page/eventInfo.html
@@ -2,9 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB0s69v5OFVxuH0cN5IS96B3jwhnjB7tTo"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDlz0NQ1mc6_UU6OHExGKIrpnkJ5q9BqPs"><script>
+
     <script src="script.js"></script>
     <link rel="stylesheet" href="style.css">
+    <title>Event Info></title>
   </head>
   <body>
     <h2>Event Information</h2>

--- a/src/main/webapp/event-info-page/eventInfo.html
+++ b/src/main/webapp/event-info-page/eventInfo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyB0s69v5OFVxuH0cN5IS96B3jwhnjB7tTo"></script>
+    <script src="script.js"></script>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <h2>Event Information</h2>
+    <span>Name:  </span> <span id="name">Cycle bun</span></br>
+    </br>
+    <span>Description:  </span><span id="description">Experience the burn of cycling drills! Take on cardiovascular conditioning with an interval-driven workout.</span></br>
+    </br>
+    <span>Name of Location:  </span><span id="location">Students Recreation Center</span></br>
+    </br>
+    <span>Date:  </span><span id="date">June 22 - August 24</span></br>
+    </br>
+    <body onload="createMap();">
+        <div id="map"></div>
+  </body>
+</html>

--- a/src/main/webapp/event-info-page/eventInfo.html
+++ b/src/main/webapp/event-info-page/eventInfo.html
@@ -12,7 +12,7 @@
     </br>
     <span>Description:  </span><span id="description">Experience the burn of cycling drills! Take on cardiovascular conditioning with an interval-driven workout.</span></br>
     </br>
-    <span>Name of Location:  </span><span id="location">Students Recreation Center</span></br>
+    <span>Building Name:  </span><span id="location">Students Recreation Center</span></br>
     </br>
     <span>Date:  </span><span id="date">June 22 - August 24</span></br>
     </br>

--- a/src/main/webapp/event-info-page/eventInfo.html
+++ b/src/main/webapp/event-info-page/eventInfo.html
@@ -2,8 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDlz0NQ1mc6_UU6OHExGKIrpnkJ5q9BqPs"><script>
-
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDlz0NQ1mc6_UU6OHExGKIrpnkJ5q9BqPs"></script>
     <script src="script.js"></script>
     <link rel="stylesheet" href="style.css">
     <title>Event Info></title>

--- a/src/main/webapp/event-info-page/script.js
+++ b/src/main/webapp/event-info-page/script.js
@@ -1,0 +1,11 @@
+function createMap() {
+    const map = new google.maps.Map(
+        document.getElementById('map'),
+        {center: {lat: 33.97919947216425, lng: -117.32849493862577}, zoom: 16});
+
+    const trexMarker = new google.maps.Marker({
+      position: {lat: 33.97919947216425, lng: -117.32849493862577},
+      map: map,
+      title: 'Cycle Bun'
+    });
+} 

--- a/src/main/webapp/event-info-page/style.css
+++ b/src/main/webapp/event-info-page/style.css
@@ -1,0 +1,5 @@
+#map {
+    border: thin solid black;
+    height: 500px;
+    width: 500px;
+} 


### PR DESCRIPTION
**Hi guys! I re-create the pull request to merge into development branch.**

![Screen Shot 2022-07-01 at 5 24 36 PM](https://user-images.githubusercontent.com/50930998/177018105-fa03f7c0-d0ac-4a44-9344-e93a7d9af878.png)


Front-end of event information page.
The server-side part is not implemented.
We can later fetch the name of the event, description, location, date, and coordinate from the server and input corresponding data to this page.