### PR TITLE
Revert directory change in pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 .settings/
 target/
+.theia/

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
                 ${project.build.directory}/classes/META-INF/resources
               </outputDirectory>
               <resources>
-                <resource><directory>./src/main/webapp/home-page</directory></resource>
+                <resource><directory>./src/main/webapp</directory></resource>
               </resources>
             </configuration>
           </execution>


### PR DESCRIPTION
I changed the directory in pom.xml since otherwise the first page to show up would be a listing of the folders we have in the "webapp" folder, but this has been causing issues when running a local server since it says that some files cannot be found. I'm not sure what the best fix would be--I tried to figure out if there was a way to change the first page that shows up and this didn't work out, so maybe we need to take the home page "index.html" outside of the "home-page" folder?