### PR TITLE
Enforce HTTPS connections

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,1 +1,7 @@
 runtime: java11
+
+handlers:
+  - url: /.*
+    secure: always
+    redirect_http_response_code: 301
+    script: auto

--- a/src/main/java/com/google/sps/servlets/EventServlet.java
+++ b/src/main/java/com/google/sps/servlets/EventServlet.java
@@ -112,7 +112,7 @@ public class EventServlet extends HttpServlet {
     TimestampValue event_time =
         TimestampValue.of(Timestamp.parseTimestamp(request.getParameter("utc-date")));
     String event_type = request.getParameter("event_type");
-    String event_sub = request.getParameter("subject");
+    String event_sub = (event_type.equals("Social")) ? "" : request.getParameter("subject");
     Long event_school_L = Long.parseLong(request.getParameter("school_id"));
 
     // Store to the Datastore

--- a/src/main/webapp/event-info-page/eventInfo.html
+++ b/src/main/webapp/event-info-page/eventInfo.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Event Info></title>
+    <title>Event Info</title>
     <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDlz0NQ1mc6_UU6OHExGKIrpnkJ5q9BqPs"></script>
     <script src="script.js"></script>


### PR DESCRIPTION
About: When testing the deployed website, I noticed that even if you visited the site through an https connection, after submitting an event, the connection would become http (because the request made to the servlet is http). The changes made enforce https connections. The reason why this matters is because Chrome does not allow geolocation if the connection is not secure, and geolocation is used to sort events by distance.

Changes: In src/main/appengine/app.yaml, a handler element is added to enforce secure connections. (source: https://www.trendmicro.com/cloudoneconformity/knowledge-base/gcp/ComputeEngine/enable-https-for-app-engine-applications.html)

Bug fix: "Social" events should have an empty string for the subject. This was removed in an earlier commit by accident but has been reinstated.